### PR TITLE
Replace sun/moon theme icons with a toggle switch

### DIFF
--- a/docs/blog.html
+++ b/docs/blog.html
@@ -17,8 +17,9 @@
       <a href="software-data.html">Code & Data</a>
       <a href="blog.html" class="active">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/blog/2026-02-03-hello-world.html
+++ b/docs/blog/2026-02-03-hello-world.html
@@ -33,8 +33,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html" class="active">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/blog/2026-02-03-nsbm-1.html
+++ b/docs/blog/2026-02-03-nsbm-1.html
@@ -33,8 +33,9 @@
       <a href="../software-data.html">Software & Data</a>
       <a href="../blog.html" class="active">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/blog/2026-02-03-testing.html
+++ b/docs/blog/2026-02-03-testing.html
@@ -33,8 +33,9 @@
       <a href="../software-data.html">Software & Data</a>
       <a href="../blog.html" class="active">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/blog/2026-02-05-nsbm-2.html
+++ b/docs/blog/2026-02-05-nsbm-2.html
@@ -33,8 +33,9 @@
       <a href="../software-data.html">Software & Data</a>
       <a href="../blog.html" class="active">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/books/dcss.html
+++ b/docs/books/dcss.html
@@ -17,8 +17,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/books/face-to-face.html
+++ b/docs/books/face-to-face.html
@@ -17,8 +17,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/books/industrial-development.html
+++ b/docs/books/industrial-development.html
@@ -17,8 +17,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/books/sage-handbook.html
+++ b/docs/books/sage-handbook.html
@@ -17,8 +17,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/cv.html
+++ b/docs/cv.html
@@ -16,8 +16,9 @@
             <a href="software-data.html">Code & Data</a>
             <a href="blog.html">Blog</a>
             <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-                <span class="icon-moon">☽</span>
-                <span class="icon-sun">☼</span>
+                <span class="toggle-track">
+                  <span class="toggle-thumb"></span>
+                </span>
             </button>
         </nav>
     </header>

--- a/docs/data.html
+++ b/docs/data.html
@@ -18,8 +18,9 @@
       <a href="blog.html">Blog</a>
       <a href="cv.html">CV</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,8 +17,9 @@
       <a href="software-data.html">Code & Data</a>
       <a href="blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>
@@ -58,12 +59,6 @@ O: AA-4055
 
 <h2>Latest Posts</h2>
 <div class="cards">
-
-  <a href="blog/2026-02-03-hello-world.html" class="card">
-    <div class="meta">2026-02-03</div>
-    <h3>Hello World!</h3>
-    <p>These are the first words from every blog, right?</p>
-  </a>
 
 </div>
 

--- a/docs/research.html
+++ b/docs/research.html
@@ -17,8 +17,9 @@
       <a href="software-data.html">Code & Data</a>
       <a href="blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/software-data.html
+++ b/docs/software-data.html
@@ -17,8 +17,9 @@
       <a href="software-data.html" class="active">Code & Data</a>
       <a href="blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/software.html
+++ b/docs/software.html
@@ -18,8 +18,9 @@
       <a href="blog.html">Blog</a>
       <a href="cv.html">CV</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -76,32 +76,40 @@ nav a.nav-home {
   background: none;
   border: none;
   cursor: pointer;
-  color: var(--text-muted);
-  font-size: 1.1rem;
   padding: 0.5rem;
   margin-left: auto;
-  transition: color 0.2s;
+  display: flex;
+  align-items: center;
 }
 
-.theme-toggle:hover {
-  color: var(--text);
+.toggle-track {
+  display: block;
+  width: 32px;
+  height: 18px;
+  background: var(--text-muted);
+  border-radius: 9px;
+  position: relative;
+  transition: background 0.2s;
 }
 
-/* Theme toggle icons - moon shown in light mode, sun in dark mode */
-.icon-sun {
-  display: none;
+.toggle-thumb {
+  display: block;
+  width: 14px;
+  height: 14px;
+  background: var(--bg);
+  border-radius: 50%;
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  transition: transform 0.2s;
 }
 
-.icon-moon {
-  display: inline;
+[data-theme="dark"] .toggle-thumb {
+  transform: translateX(14px);
 }
 
-[data-theme="dark"] .icon-moon {
-  display: none;
-}
-
-[data-theme="dark"] .icon-sun {
-  display: inline;
+.theme-toggle:hover .toggle-track {
+  background: var(--text);
 }
 
 /* Main */

--- a/docs/supervision.html
+++ b/docs/supervision.html
@@ -18,8 +18,9 @@
       <a href="blog.html">Blog</a>
       <a href="cv.html">CV</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/teaching.html
+++ b/docs/teaching.html
@@ -17,8 +17,9 @@
       <a href="software-data.html">Code & Data</a>
       <a href="blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/docs/teaching/3040.html
+++ b/docs/teaching/3040.html
@@ -17,8 +17,9 @@
       <a href="../software-data.html">Code & Data</a>
       <a href="../blog.html">Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>

--- a/templates/base.html
+++ b/templates/base.html
@@ -17,8 +17,9 @@
       <a href="{{ base_path }}software-data.html"{% if active == 'software' %} class="active"{% endif %}>Code & Data</a>
       <a href="{{ base_path }}blog.html"{% if active == 'blog' %} class="active"{% endif %}>Blog</a>
       <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle theme">
-        <span class="icon-moon">☽</span>
-        <span class="icon-sun">☼</span>
+        <span class="toggle-track">
+          <span class="toggle-thumb"></span>
+        </span>
       </button>
     </nav>
   </header>


### PR DESCRIPTION
Swap the ☽/☼ character icons for a sliding CSS toggle switch
that visually indicates the current theme state (left = light,
right = dark).

https://claude.ai/code/session_014ABfBkjPbnvtZtFAYJAJy2